### PR TITLE
Use saner defaults if tally doesn't find `vbt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,22 +136,27 @@ the results to <https://vmn-webapp.azurewebsites.net/results> (by default). Usag
 
 ```text
 usage: demo.py tally [-h] [--vote-collecting-server SERVER]
-                     [--use-bytetree-parser | --use-vbt | --skip-plaintexts]
+                     [--bytetree-parser | --vbt | --skip-plaintexts]
 
 optional arguments:
   -h, --help            show this help message and exit
   --vote-collecting-server SERVER
                         Address of vote collecting server where the script
                         POSTs the public key and GETs the ciphertexts
-  --use-bytetree-parser
-                        Use bytetree.py to parse plaintexts. File must be
+  --bytetree-parser     Use bytetree.py to parse plaintexts. File must be
                         located in directory '../webdemo/' relative to this
                         script's location
-  --use-vbt             Use `vbt` to parse plaintexts. Must be available in
+  --vbt                 Use `vbt` to parse plaintexts. Must be available in
                         $PATH
   --skip-plaintexts     Do not parse the plaintexts and do not upload them to
                         the results page
 ```
+
+`vbt` is needed to parse the plaintexts locally. Follow the installation instructions on <https://www.verificatum.org/>
+to compile that program since it's included with [verificatum-vcr](https://github.com/verificatum/verificatum-vcr). The
+program is used to parse verificatum's byte tree format and output a JSON representation. Alternatively, the
+`--bytetree-parser` flag uses a python port of the needed functionality through the
+[`webdemo/bytetree.py`](webdemo/bytetree.py) file.
 
 ### Shutting down all servers
 


### PR DESCRIPTION
@slarse  I'd rather not make the bytetree.py parser the default since it's just a naive port of verificatum's `vbt` and might not be 100% correct.

Fixes #9